### PR TITLE
Full path for reusable action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
   test-docker-build-push:
     name: Test docker build/push reusable workflow
-    uses: ./.github/workflows/docker-build-push.yml
+    uses: .github/workflows/docker-build-push.yml
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
   test-docker-build-push:
     name: Test docker build/push reusable workflow
-    uses: .github/workflows/docker-build-push.yml
+    uses: AplinkosMinisterija/reusable-workflows/.github/workflows/docker-build-push.yml
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
 
   test-docker-build-push:
     name: Test docker build/push reusable workflow
-    uses: AplinkosMinisterija/reusable-workflows/.github/workflows/docker-build-push.yml
+    uses: ./.github/workflows/docker-build-push.yml
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: ${{inputs.git-ref}} && 0 || 1 # In git-ref case: fetch all history for all branches and tags
 
       - name: Build, tag & push docker image
-        uses: AplinkosMinisterija/reusable-workflows/.github/actions/docker-build-tag-push
+        uses: AplinkosMinisterija/reusable-workflows/.github/actions/docker-build-tag-push@main
         with:
           docker-image: ${{inputs.docker-image}}
           environment: ${{inputs.environment}}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -64,7 +64,7 @@ jobs:
           fetch-depth: ${{inputs.git-ref}} && 0 || 1 # In git-ref case: fetch all history for all branches and tags
 
       - name: Build, tag & push docker image
-        uses: ./.github/actions/docker-build-tag-push
+        uses: AplinkosMinisterija/reusable-workflows/.github/actions/docker-build-tag-push
         with:
           docker-image: ${{inputs.docker-image}}
           environment: ${{inputs.environment}}


### PR DESCRIPTION
Fixes:
```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/biip-zuvinimas-api/biip-zuvinimas-api/.github/actions/docker-build-tag-push'. Did you forget to run actions/checkout before running your local action?
```
