### PR TITLE
Always pull base docker image

### DIFF
--- a/.github/actions/docker-build-tag-push/action.yml
+++ b/.github/actions/docker-build-tag-push/action.yml
@@ -88,6 +88,7 @@ runs:
         builder: ${{ steps.buildx.outputs.name }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        pull: true
 
     - name: Output image tag
       id: image-tag


### PR DESCRIPTION
Update base image to the latest version by enabling the "pull" option.

This change ensures that the latest version of the base image is pulled before building, tagging, and pushing the Docker image.