### PR TITLE
feat(biip-deploy): pass Sentry token/url as build-args when enable-sentry

### DIFF
--- a/.github/workflows/biip-deploy.yml
+++ b/.github/workflows/biip-deploy.yml
@@ -119,6 +119,8 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
             ENVIRONMENT=${{ steps.environment.outputs.lowercase }}
+            ${{ inputs.enable-sentry && format('SENTRY_AUTH_TOKEN={0}', secrets.BIIP_SENTRY_AUTH_TOKEN) || '' }}
+            ${{ inputs.enable-sentry && format('SENTRY_URL={0}', secrets.BIIP_SENTRY_URL) || '' }}
             ${{inputs.build-args}}
           docker-context: ${{inputs.docker-context}}
           docker-platforms: ${{inputs.docker-platforms}}


### PR DESCRIPTION
## Why

`biip-medziokle-web` uploads sourcemaps to Sentry from inside the Docker build (`@sentry/vite-plugin`, gated on `SENTRY_AUTH_TOKEN`). The token never arrived: callers **cannot** put `${{ secrets.* }}` in a reusable-workflow call's `with:` block (secrets context is not available there), so there was no way to pass it via the `build-args` input from the consuming repo. Result — production stacks in Sentry are minified (release 1.3.2 has 0 artifacts).

## What

When the existing `enable-sentry` input is true, append to docker build-args:

- `SENTRY_AUTH_TOKEN` (from `BIIP_SENTRY_AUTH_TOKEN`)
- `SENTRY_URL` (from `BIIP_SENTRY_URL`)

## Blast radius

- `enable-sentry: false` → lines render empty; `docker/build-push-action` drops empty entries. No change.
- `enable-sentry: true` with a Dockerfile that doesn't declare these ARGs (all current consumers) → buildx logs an *unconsumed build-arg* warning, build unaffected; unused args are not embedded in image layers.
- Secret values are masked in Actions logs as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)