### PR TITLE
ci: default reusable workflows to self-hosted am-github-runner

### DIFF
--- a/.github/workflows/biip-deploy.yml
+++ b/.github/workflows/biip-deploy.yml
@@ -16,10 +16,10 @@ on:
         required: true
         type: string
       runs-on:
-        description: "Optional input to set an operating systems which the workflow uses. Defaults to ubuntu-latest if not set"
+        description: "Optional input to set the runner the workflow uses. Defaults to the self-hosted am-github-runner (avoids GitHub-hosted billing limits). Pass 'ubuntu-latest' to use a GitHub-hosted runner."
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "am-github-runner"
       container:
         description: "Optional input to set a container which the workflow uses"
         required: false

--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       runs-on:
-        description: "Optional input to set an operating systems which the workflow uses. Defaults to ubuntu-latest if not set"
+        description: "Optional input to set the runner the workflow uses. Defaults to the self-hosted am-github-runner (avoids GitHub-hosted billing limits). Pass 'ubuntu-latest' to use a GitHub-hosted runner."
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "am-github-runner"
       timeout-minutes:
         description: "Optional input to set timeout minutes. Defaults to 15"
         required: false

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -16,10 +16,10 @@ on:
         required: true
         type: string
       runs-on:
-        description: "Optional input to set an operating systems which the workflow uses. Defaults to ubuntu-latest if not set"
+        description: "Optional input to set the runner the workflow uses. Defaults to the self-hosted am-github-runner (avoids GitHub-hosted billing limits). Pass 'ubuntu-latest' to use a GitHub-hosted runner."
         required: false
         type: string
-        default: "ubuntu-latest"
+        default: "am-github-runner"
       docker-context:
         description: "Optional input to set docker context"
         required: false


### PR DESCRIPTION
## Kodėl

Org Actions spending limit blokuoja GitHub-hosted runnerius (*"job was not started because recent account payments have failed or your spending limit needs to be increased"*). Vakar dėl to krito HR deploy'ai; sprendimas — naudoti jau egzistuojantį self-hosted `am-github-runner` (ARC, nepriklauso nuo GitHub-hosted billingo).

## Kas pakeista

`runs-on` input **default** pakeistas `ubuntu-latest` → `am-github-runner` trijuose reusable workflow'uose:
- `docker-build-push.yml`
- `biip-deploy.yml`
- `composer-update.yml`

## Poveikis

- Consumer'iai, kurie **nepaduoda** `runs-on` (dauguma biip-* deploy'ų ir nauji projektai), automatiškai pereina ant self-hosted — be redagavimo.
- Kas paduoda `runs-on: am-github-runner` rankiniu — nepasikeičia.
- Norint GitHub-hosted, galima eksplicitiškai paduoti `runs-on: ubuntu-latest`.

`ci.yml` (Checkov saugumo skenas) paliktas ant `ubuntu-latest` — saugumo skenai nemigruojami.

🤖 Generated with [Claude Code](https://claude.com/claude-code)