### PR TITLE
biip-deploy: allow overriding the buildx cache backend + skip QEMU on amd64

### DIFF
--- a/.github/actions/docker-build-tag-push/action.yml
+++ b/.github/actions/docker-build-tag-push/action.yml
@@ -71,6 +71,8 @@ runs:
 
     - name: Set up QEMU
       id: qemu
+      # QEMU is only needed for cross-platform emulation; skip it for plain amd64 builds
+      if: ${{ inputs.docker-platforms != 'linux/amd64' }}
       uses: docker/setup-qemu-action@v4
 
     - name: Setup buildx

--- a/.github/workflows/biip-deploy.yml
+++ b/.github/workflows/biip-deploy.yml
@@ -49,6 +49,16 @@ on:
         required: false
         type: boolean
         default: false
+      cache-from:
+        description: "Optional input to set buildx cache-from. Defaults to GitHub Actions cache"
+        required: false
+        type: string
+        default: "type=gha"
+      cache-to:
+        description: "Optional input to set buildx cache-to. Defaults to GitHub Actions cache"
+        required: false
+        type: string
+        default: "type=gha,mode=max,ignore-error=true"
 
     secrets:
       BIIP_TRIGGER_DEPLOY_REPOSITORY:
@@ -124,6 +134,8 @@ jobs:
             ${{inputs.build-args}}
           docker-context: ${{inputs.docker-context}}
           docker-platforms: ${{inputs.docker-platforms}}
+          cache-from: ${{inputs.cache-from}}
+          cache-to: ${{inputs.cache-to}}
 
       - name: Trigger deploy
         uses: convictional/trigger-workflow-and-wait@v1.6.5


### PR DESCRIPTION
## What

- `biip-deploy.yml` gains optional `cache-from` / `cache-to` inputs, forwarded to the `docker-build-tag-push` action (which already supported them). Defaults stay `type=gha`, so nothing changes for existing callers.
- `docker-build-tag-push` skips the QEMU setup step when building plain `linux/amd64` (the default) — QEMU is only needed for cross-platform emulation.

## Why

Measured on the biip-alis-* dev deploys: the buildx GHA cache backend downloads the cached `yarn install` layer (529 MB for biip-alis-web) at ~2 MB/s to the self-hosted runner — ~224 s per build, ~80 % of total build time, even on a full cache hit. A ghcr.io registry cache (`type=registry,ref=ghcr.io/...:buildcache`) pulls far faster from the same registry the images already live in, and is not subject to the 10 GB GHA cache eviction. This PR only adds the opt-in knob; the biip-alis-* repos will opt in via follow-up PRs.

## Notes

Follow-up PRs in biip-alis-api / biip-alis-web / biip-alis-admin-web depend on this one being merged first (unknown `with:` inputs fail workflow validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)